### PR TITLE
Integrate change required for Oracle bug 27311375 

### DIFF
--- a/wadl/pom.xml
+++ b/wadl/pom.xml
@@ -52,7 +52,7 @@
     <groupId>org.jvnet.ws.wadl</groupId>
     <artifactId>wadl</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.7-SNAPSHOT</version>
+    <version>1.1.8-SNAPSHOT</version>
     <name>WADL</name>
     <url>http://wadl.java.net/</url>
 

--- a/wadl/wadl-ant/pom.xml
+++ b/wadl/wadl-ant/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jvnet.ws.wadl</groupId>
         <artifactId>wadl</artifactId>
-        <version>1.1.7-SNAPSHOT</version>
+        <version>1.1.8-SNAPSHOT</version>
     </parent>
     <artifactId>wadl-ant</artifactId>
     <name>WADL Ant Task</name>

--- a/wadl/wadl-cmdline/pom.xml
+++ b/wadl/wadl-cmdline/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jvnet.ws.wadl</groupId>
         <artifactId>wadl</artifactId>
-        <version>1.1.7-SNAPSHOT</version>
+        <version>1.1.8-SNAPSHOT</version>
     </parent>
     <artifactId>wadl-cmdline</artifactId>
     <packaging>jar</packaging>

--- a/wadl/wadl-core/pom.xml
+++ b/wadl/wadl-core/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.jvnet.ws.wadl</groupId>
         <artifactId>wadl</artifactId>
-        <version>1.1.7-SNAPSHOT</version>
+        <version>1.1.8-SNAPSHOT</version>
     </parent>
     <artifactId>wadl-core</artifactId>
     <name>WADL Core</name>
@@ -106,18 +106,24 @@
             <artifactId>jersey-common</artifactId>
             <version>${jersey2.version}</version>
         </dependency>
-        
+        <!-- Update to version 0.5.1
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>
             <artifactId>jsonschema2pojo-core</artifactId>
             <version>0.4.4</version>
         </dependency>
-
+        -->
+        <!-- https://mvnrepository.com/artifact/org.jsonschema2pojo/jsonschema2pojo-core -->
+        <dependency>
+            <groupId>org.jsonschema2pojo</groupId>
+            <artifactId>jsonschema2pojo-core</artifactId>
+            <version>0.5.1</version>
+        </dependency>
         <!-- Required to include the upgrade.xsl file -->
         <dependency>
             <groupId>org.jvnet.ws.wadl</groupId>
             <artifactId>wadl-xslt</artifactId>
-            <version>1.1.7-SNAPSHOT</version>
+            <version>1.1.8-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/wadl/wadl-core/src/main/java/org/jvnet/ws/wadl2java/Wadl2Java.java
+++ b/wadl/wadl-core/src/main/java/org/jvnet/ws/wadl2java/Wadl2Java.java
@@ -594,7 +594,9 @@ public class Wadl2Java {
                     }
 
                 };
-                AnnotatorFactory af = new AnnotatorFactory();
+                // JRC: AnnotatorFactory constructor now takes argument of
+                // type GenerationConfig.
+                AnnotatorFactory af = new AnnotatorFactory(gc);
 
                 SchemaMapper sm = new SchemaMapper(
                         new RuleFactory(

--- a/wadl/wadl-dist/pom.xml
+++ b/wadl/wadl-dist/pom.xml
@@ -46,7 +46,7 @@
     <parent>
         <groupId>org.jvnet.ws.wadl</groupId>
         <artifactId>wadl</artifactId>
-        <version>1.1.7-SNAPSHOT</version>
+        <version>1.1.8-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
     <artifactId>wadl-dist</artifactId>

--- a/wadl/wadl-maven-plugin/pom.xml
+++ b/wadl/wadl-maven-plugin/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.jvnet.ws.wadl</groupId>
         <artifactId>wadl</artifactId>
-        <version>1.1.7-SNAPSHOT</version>
+        <version>1.1.8-SNAPSHOT</version>
     </parent>
     <artifactId>wadl-client-plugin</artifactId>
     <name>WADL Maven Plugin</name>
@@ -128,7 +128,6 @@
             <version>2.15</version>
             <scope>test</scope>
         </dependency>         
-        
 
         <!-- Only in place to provide implementation of UriBuilder -->
         <dependency>
@@ -150,7 +149,7 @@
             <version>${jersey1.version}</version>
             <scope>test</scope>
         </dependency>
-        
+     
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-jaxrs</artifactId>

--- a/wadl/wadl-maven-plugin/src/test/java/org/jvnet/ws/wadl/maven/AbstractJavaWadl2JavaMojoTest.java
+++ b/wadl/wadl-maven-plugin/src/test/java/org/jvnet/ws/wadl/maven/AbstractJavaWadl2JavaMojoTest.java
@@ -305,13 +305,34 @@ public abstract class AbstractJavaWadl2JavaMojoTest<ClientType> extends Abstract
                 .invoke("One", "Two", String.class);
         
         assertThat(result, not(nullValue()));
-        assertThat("http://otherhost/newsSearch?query=Two&appid=One",
-                equalTo(_requests.get(0).getURI().toString()));
-    }    
-    
 
-    
-    
+        URI target = URI.create("http://otherhost/newsSearch?query=Two&appid=One");
+
+
+        URI uri = _requests.get(0).getURI();
+
+        compareUriAndSortQueryParams(target, uri);
+
+    }
+
+    private void compareUriAndSortQueryParams(URI target, URI uri) {
+        assertThat(target.getHost(),
+                equalTo(uri.getHost()));
+        assertThat(target.getPath(),
+                equalTo(uri.getPath()));
+
+        String targetQueryParam[] = target.getQuery().split("&");
+        String uriQueryParams[] = uri.getQuery().split("&");
+        Arrays.sort(targetQueryParam);
+        Arrays.sort(uriQueryParams);
+
+        assertThat(
+                targetQueryParam,
+                equalTo(
+                    uriQueryParams));
+    }
+
+
     /**
      * Tests the case in which a valid wadl file exists, and it it contains a method that returns
      * just text/plain
@@ -1257,7 +1278,8 @@ public abstract class AbstractJavaWadl2JavaMojoTest<ClientType> extends Abstract
         String actualURI = _requests.get(0).getURI().toString();
         
         // Removed until Jersey-1369 is resolved
-        assertEquals("We should have a really funky URI",uri, actualURI);
+        compareUriAndSortQueryParams(
+                URI.create(actualURI), URI.create(uri));
         
 
         // Populate a canned response again

--- a/wadl/wadl-xslt/pom.xml
+++ b/wadl/wadl-xslt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jvnet.ws.wadl</groupId>
         <artifactId>wadl</artifactId>
-        <version>1.1.7-SNAPSHOT</version>
+        <version>1.1.8-SNAPSHOT</version>
     </parent>
     <artifactId>wadl-xslt</artifactId>
     <name>WADL XSLT</name>


### PR DESCRIPTION
Relating to a out of date version of jackson-databind-2.2.0.jar, which had a
security vulnerability, to a newer version of the jar. The jar now used
is jackson-databind-2.9.1.jar.

This required some code changea and updates to some tests.

Changes provided by Jose Cronenbold of the Oracle JDeveloper team.